### PR TITLE
Upgrade numpy and explicitly install patsy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 jupyterlab==0.35.3
 keras==2.2.4
 matplotlib==3.0.2
-numpy==1.15.4
+numpy==1.16.1
 pandas==0.23.4
+patsy==0.5.1
 pyfolio==0.9.0
 scikit-image==0.14.1
 scikit-learn==0.20.2


### PR DESCRIPTION
Windows required upgrading numpy refs #31 to avoid ModuleError

For TrendFollow notebook, patsy needed to be an explicit install 