### PR TITLE
Fix MlFinLab issues

### DIFF
--- a/Advances in Financial Machine Learning/Fractionally Differentiated Features/Chapter5_Exercises.ipynb
+++ b/Advances in Financial Machine Learning/Fractionally Differentiated Features/Chapter5_Exercises.ipynb
@@ -1150,18 +1150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_min_ffd(close_prices):\n",
-    "    out = pd.DataFrame(columns=['adfStat', 'pVal', 'lags', 'nObs', '95% conf', 'corr'])\n",
-    "    for d in np.linspace(0, 1, 11):\n",
-    "        df1 = np.log(close_prices[['close']]).resample('1D').last()  # downcast to daily obs        \n",
-    "        df1.dropna(inplace=True)\n",
-    "        df2 = fracdiff.frac_diff_ffd(df1, diff_amt=d, thresh=0.01).dropna()\n",
-    "        corr = np.corrcoef(df1.loc[df2.index, 'close'], df2['close'])[0, 1]\n",
-    "        df2 = adfuller(df2['close'], maxlag=1, regression='c', autolag=None)\n",
-    "        out.loc[d] = list(df2[:4]) + [df2[4]['5%']] + [corr]  # with critical value\n",
-    "    out[['adfStat', 'corr']].plot(secondary_y='adfStat', figsize=(10, 8))\n",
-    "    plt.axhline(out['95% conf'].mean(), linewidth=1, color='r', linestyle='dotted')\n",
-    "    return"
+    "# Using plot_min_ffd function implemented in MlFinLab"
    ]
   },
   {


### PR DESCRIPTION
# Description

This PR is needed to reflect the changes in MlFinLab after [PR #402](https://github.com/hudson-and-thames/mlfinlab/pull/402) and adjust the examples in the notebooks accordingly:
 
After fix [#97](https://github.com/hudson-and-thames/mlfinlab/issues/97) 
- `Chapter5_Exercises.ipynb` now uses `plot_min_ffd` function from MlFinLab
